### PR TITLE
Use strict version of subcomponents when building the full bundle RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Gravitee.io - Packages (RPM)
+
+Repository containing the tooling and scripts to build and publish RPM packages of Gravitee.io to [PackageCloud](https://packagecloud.io/graviteeio/rpms).

--- a/am/3.x/build.sh
+++ b/am/3.x/build.sh
@@ -52,27 +52,27 @@ build_access_gateway() {
         cp build/files/init.d/graviteeio-am-gateway ${TEMPLATE_DIR}/etc/init.d
 
 	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-		--rpm-user ${USER} \
-          	--rpm-group ${USER} \
-          	--rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-                --rpm-attr "0755,root,root:/etc/init.d/graviteeio-am-gateway" \
-          	--directories /opt/graviteeio \
-        	--before-install build/scripts/gateway/preinst.rpm \
-        	--after-install build/scripts/gateway/postinst.rpm \
-        	--before-remove build/scripts/gateway/prerm.rpm \
-        	--after-remove build/scripts/gateway/postrm.rpm \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-		-s dir -v ${VERSION}  \
-  		--license "${LICENSE}" \
-  		--vendor "${VENDOR}" \
-  		--maintainer "${MAINTAINER}" \
-  		--architecture ${ARCH} \
-  		--url "${URL}" \
-  		--description  "${DESC}: Access Gateway" \
-  		--config-files ${TEMPLATE_DIR}/opt/graviteeio/am/graviteeio-am-gateway-${VERSION}/config \
-  		--verbose \
-		-n ${PKGNAME}-gateway-3x
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+            --rpm-attr "0755,root,root:/etc/init.d/graviteeio-am-gateway" \
+            --directories /opt/graviteeio \
+            --before-install build/scripts/gateway/preinst.rpm \
+            --after-install build/scripts/gateway/postinst.rpm \
+            --before-remove build/scripts/gateway/prerm.rpm \
+            --after-remove build/scripts/gateway/postrm.rpm \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}: Access Gateway" \
+            --config-files ${TEMPLATE_DIR}/opt/graviteeio/am/graviteeio-am-gateway-${VERSION}/config \
+            --verbose \
+            -n ${PKGNAME}-gateway-3x
 }
 
 build_management_api() {
@@ -89,27 +89,27 @@ build_management_api() {
         cp build/files/init.d/graviteeio-am-management-api ${TEMPLATE_DIR}/etc/init.d
 
 	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-                --rpm-user ${USER} \
-                --rpm-group ${USER} \
-                --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-                --rpm-attr "0755,root,root:/etc/init.d/graviteeio-am-management-api" \
-                --directories /opt/graviteeio \
-                --before-install build/scripts/management-api/preinst.rpm \
-                --after-install build/scripts/management-api/postinst.rpm \
-                --before-remove build/scripts/management-api/prerm.rpm \
-                --after-remove build/scripts/management-api/postrm.rpm \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-                -s dir -v ${VERSION}  \
-                --license "${LICENSE}" \
-                --vendor "${VENDOR}" \
-                --maintainer "${MAINTAINER}" \
-                --architecture ${ARCH} \
-                --url "${URL}" \
-                --description  "${DESC}: Management API" \
-                --config-files ${TEMPLATE_DIR}/opt/graviteeio/am/graviteeio-am-management-api-${VERSION}/config \
-                --verbose \
-                -n ${PKGNAME}-management-api-3x
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+            --rpm-attr "0755,root,root:/etc/init.d/graviteeio-am-management-api" \
+            --directories /opt/graviteeio \
+            --before-install build/scripts/management-api/preinst.rpm \
+            --after-install build/scripts/management-api/postinst.rpm \
+            --before-remove build/scripts/management-api/prerm.rpm \
+            --after-remove build/scripts/management-api/postrm.rpm \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}: Management API" \
+            --config-files ${TEMPLATE_DIR}/opt/graviteeio/am/graviteeio-am-management-api-${VERSION}/config \
+            --verbose \
+            -n ${PKGNAME}-management-api-3x
 }
 
 build_management_ui() {
@@ -123,52 +123,52 @@ build_management_ui() {
 	cp build/files/graviteeio-am-management-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
 
 	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-                --rpm-user ${USER} \
-                --rpm-group ${USER} \
-                --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-                --directories /opt/graviteeio \
-		--before-install build/scripts/management-ui/preinst.rpm \
-                --after-install build/scripts/management-ui/postinst.rpm \
-                --before-remove build/scripts/management-ui/prerm.rpm \
-                --after-remove build/scripts/management-ui/postrm.rpm \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-                -s dir -v ${VERSION}  \
-                --license "${LICENSE}" \
-                --vendor "${VENDOR}" \
-                --maintainer "${MAINTAINER}" \
-                --architecture ${ARCH} \
-                --url "${URL}" \
-                --description  "${DESC}: Management UI" \
-                --depends nginx \
-		--config-files ${TEMPLATE_DIR}/opt/graviteeio/am/graviteeio-am-management-ui-${VERSION}/constants.json \
-                --verbose \
-                -n ${PKGNAME}-management-ui-3x
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+            --directories /opt/graviteeio \
+            --before-install build/scripts/management-ui/preinst.rpm \
+            --after-install build/scripts/management-ui/postinst.rpm \
+            --before-remove build/scripts/management-ui/prerm.rpm \
+            --after-remove build/scripts/management-ui/postrm.rpm \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}: Management UI" \
+            --depends nginx \
+            --config-files ${TEMPLATE_DIR}/opt/graviteeio/am/graviteeio-am-management-ui-${VERSION}/constants.json \
+            --verbose \
+            -n ${PKGNAME}-management-ui-3x
 }
 
 build_full() {
-        # Dirty hack to avoid issues with FPM
-        rm -fr build/skel/
-        mkdir -p ${TEMPLATE_DIR}
+  # Dirty hack to avoid issues with FPM
+  rm -fr build/skel/
+  mkdir -p ${TEMPLATE_DIR}
 
-        docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-                --rpm-user ${USER} \
-                --rpm-group ${USER} \
-                --rpm-attr "0750,${USER},${USER}:/opt/graviteeio" \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-                -s dir -v ${VERSION}  \
-                --license "${LICENSE}" \
-                --vendor "${VENDOR}" \
-                --maintainer "${MAINTAINER}" \
-                --architecture ${ARCH} \
-                --url "${URL}" \
-                --description  "${DESC}" \
-                --depends "${PKGNAME}-management-ui-3x >= ${VERSION}" \
-                --depends "${PKGNAME}-management-api-3x >= ${VERSION}" \
-                --depends "${PKGNAME}-gateway-3x >= ${VERSION}" \
-                --verbose \
-                -n ${PKGNAME}-3x
+  docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0750,${USER},${USER}:/opt/graviteeio" \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}" \
+            --depends "${PKGNAME}-management-ui-3x = ${VERSION}" \
+            --depends "${PKGNAME}-management-api-3x = ${VERSION}" \
+            --depends "${PKGNAME}-gateway-3x = ${VERSION}" \
+            --verbose \
+            -n ${PKGNAME}-3x
 }
 
 build() {

--- a/am/3.x/build/scripts/gateway/preinst.rpm
+++ b/am/3.x/build/scripts/gateway/preinst.rpm
@@ -10,6 +10,81 @@
 #       $1=1       : indicates a new install
 #       $1=2       : indicates an upgrade
 
+checkVersionUpgrade() {
+    echo "INFO: Some version mismatch issues have been identified in the previous version of this RPM package."
+    echo "INFO: To avoid any destructive changes if the upgrade is applied, some checks on the versions will be ran."
+
+    # Get installedVersion from /opt/graviteeio/am/graviteeio-am-gateway-xxxxxxxx
+    installedVersion=$(ls -d /opt/graviteeio/am/graviteeio-am-gateway-* | cut -d- -f4)
+    echo "Installed version: $installedVersion"
+
+    # Parse version based on format x.y.z
+    installedMajor=$(echo $installedVersion | cut -d. -f1)
+    installedMinor=$(echo $installedVersion | cut -d. -f2)
+    installedPatch=$(echo $installedVersion | cut -d. -f3)
+
+    newVersion=%{version}
+    echo "New version: $newVersion"
+
+    # Parse version based on format x.y.z
+    newVersionMajor=$(echo $newVersion | cut -d. -f1)
+    newVersionMinor=$(echo $newVersion | cut -d. -f2)
+    newVersionPatch=$(echo $newVersion | cut -d. -f3)
+
+    if [ "$installedMajor" -gt "$newVersionMajor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -gt "$newVersionMinor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -eq "$newVersionMinor" -a "$installedPatch" -gt "$newVersionPatch" ] ; then
+        echo "ERROR: You are trying to upgrade to a version ($newVersion) that is lower than the one you are currently running ($installedVersion)"
+        exit 1
+    fi
+}
+
+
+createGroupAndUserDebian() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        addgroup --quiet --system gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        adduser --quiet \
+                --system \
+                --no-create-home \
+                --home /nonexistent \
+                --ingroup gravitee \
+                --disabled-password \
+                --shell /bin/false \
+                gravitee
+        echo " OK"
+    fi
+}
+
+createGroupAndUserRedHat() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        groupadd -r gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        useradd --system \
+                --no-create-home \
+                --home-dir /nonexistent \
+                --gid gravitee \
+                --shell /sbin/nologin \
+                --comment "gravitee user" \
+                gravitee
+        echo " OK"
+    fi
+}
+
 err_exit() {
     echo "$@" >&2
     exit 1
@@ -18,54 +93,26 @@ err_exit() {
 case "$1" in
 
     # Debian ####################################################
-    install|upgrade)
-
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            addgroup --quiet --system gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            adduser --quiet \
-                    --system \
-                    --no-create-home \
-                    --home /nonexistent \
-                    --ingroup gravitee \
-                    --disabled-password \
-                    --shell /bin/false \
-                    gravitee
-            echo " OK"
-        fi
+    install)
+        createGroupAndUserDebian
     ;;
+
+    upgrade)
+        checkVersionUpgrade
+        createGroupAndUserDebian
+    ;;
+
     abort-deconfigure|abort-upgrade|abort-remove)
     ;;
 
     # RedHat ####################################################
-    1|2)
+    1)
+        createGroupAndUserRedHat
+    ;;
 
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            groupadd -r gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            useradd --system \
-                    --no-create-home \
-                    --home-dir /nonexistent \
-                    --gid gravitee \
-                    --shell /sbin/nologin \
-                    --comment "gravitee user" \
-                    gravitee
-            echo " OK"
-        fi
+    2)
+        checkVersionUpgrade
+        createGroupAndUserRedHat
     ;;
 
     *)

--- a/am/3.x/build/scripts/management-api/preinst.rpm
+++ b/am/3.x/build/scripts/management-api/preinst.rpm
@@ -10,6 +10,80 @@
 #       $1=1       : indicates a new install
 #       $1=2       : indicates an upgrade
 
+checkVersionUpgrade() {
+    echo "INFO: Some version mismatch issues have been identified in the previous version of this RPM package."
+    echo "INFO: To avoid any destructive changes if the upgrade is applied, some checks on the versions will be ran."
+
+    # Get installedVersion from /opt/graviteeio/am/graviteeio-am-management-api-xxxxxxxx
+    installedVersion=$(ls -d /opt/graviteeio/am/graviteeio-am-management-api-* | cut -d- -f5)
+    echo "Installed version: $installedVersion"
+
+    # Parse version based on format x.y.z
+    installedMajor=$(echo $installedVersion | cut -d. -f1)
+    installedMinor=$(echo $installedVersion | cut -d. -f2)
+    installedPatch=$(echo $installedVersion | cut -d. -f3)
+
+    newVersion=%{version}
+    echo "New version: $newVersion"
+
+    # Parse version based on format x.y.z
+    newVersionMajor=$(echo $newVersion | cut -d. -f1)
+    newVersionMinor=$(echo $newVersion | cut -d. -f2)
+    newVersionPatch=$(echo $newVersion | cut -d. -f3)
+
+    if [ "$installedMajor" -gt "$newVersionMajor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -gt "$newVersionMinor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -eq "$newVersionMinor" -a "$installedPatch" -gt "$newVersionPatch" ] ; then
+        echo "ERROR: You are trying to upgrade to a version ($newVersion) that is lower than the one you are currently running ($installedVersion)"
+        exit 1
+    fi
+}
+
+createGroupAndUserDebian() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        addgroup --quiet --system gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        adduser --quiet \
+                --system \
+                --no-create-home \
+                --home /nonexistent \
+                --ingroup gravitee \
+                --disabled-password \
+                --shell /bin/false \
+                gravitee
+        echo " OK"
+    fi
+}
+
+createGroupAndUserRedHat() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        groupadd -r gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        useradd --system \
+                --no-create-home \
+                --home-dir /nonexistent \
+                --gid gravitee \
+                --shell /sbin/nologin \
+                --comment "gravitee user" \
+                gravitee
+        echo " OK"
+    fi
+}
+
 err_exit() {
     echo "$@" >&2
     exit 1
@@ -18,54 +92,26 @@ err_exit() {
 case "$1" in
 
     # Debian ####################################################
-    install|upgrade)
-
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            addgroup --quiet --system gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            adduser --quiet \
-                    --system \
-                    --no-create-home \
-                    --home /nonexistent \
-                    --ingroup gravitee \
-                    --disabled-password \
-                    --shell /bin/false \
-                    gravitee
-            echo " OK"
-        fi
+    install)
+        createGroupAndUserDebian
     ;;
+
+    upgrade)
+        checkVersionUpgrade
+        createGroupAndUserDebian
+    ;;
+
     abort-deconfigure|abort-upgrade|abort-remove)
     ;;
 
     # RedHat ####################################################
-    1|2)
+    1)
+        createGroupAndUserRedHat
+    ;;
 
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            groupadd -r gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            useradd --system \
-                    --no-create-home \
-                    --home-dir /nonexistent \
-                    --gid gravitee \
-                    --shell /sbin/nologin \
-                    --comment "gravitee user" \
-                    gravitee
-            echo " OK"
-        fi
+    2)
+        checkVersionUpgrade
+        createGroupAndUserRedHat
     ;;
 
     *)

--- a/am/3.x/build/scripts/management-ui/preinst.rpm
+++ b/am/3.x/build/scripts/management-ui/preinst.rpm
@@ -10,6 +10,80 @@
 #       $1=1       : indicates a new install
 #       $1=2       : indicates an upgrade
 
+checkVersionUpgrade() {
+    echo "INFO: Some version mismatch issues have been identified in the previous version of this RPM package."
+    echo "INFO: To avoid any destructive changes if the upgrade is applied, some checks on the versions will be ran."
+
+    # Get installedVersion from /opt/graviteeio/am/graviteeio-am-management-ui-xxxxxxxx
+    installedVersion=$(ls -d /opt/graviteeio/am/graviteeio-am-management-ui-* | cut -d- -f5)
+    echo "Installed version: $installedVersion"
+
+    # Parse version based on format x.y.z
+    installedMajor=$(echo $installedVersion | cut -d. -f1)
+    installedMinor=$(echo $installedVersion | cut -d. -f2)
+    installedPatch=$(echo $installedVersion | cut -d. -f3)
+
+    newVersion=%{version}
+    echo "New version: $newVersion"
+
+    # Parse version based on format x.y.z
+    newVersionMajor=$(echo $newVersion | cut -d. -f1)
+    newVersionMinor=$(echo $newVersion | cut -d. -f2)
+    newVersionPatch=$(echo $newVersion | cut -d. -f3)
+
+    if [ "$installedMajor" -gt "$newVersionMajor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -gt "$newVersionMinor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -eq "$newVersionMinor" -a "$installedPatch" -gt "$newVersionPatch" ] ; then
+        echo "ERROR: You are trying to upgrade to a version ($newVersion) that is lower than the one you are currently running ($installedVersion)"
+        exit 1
+    fi
+}
+
+createGroupAndUserDebian() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        addgroup --quiet --system gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        adduser --quiet \
+                --system \
+                --no-create-home \
+                --home /nonexistent \
+                --ingroup gravitee \
+                --disabled-password \
+                --shell /bin/false \
+                gravitee
+        echo " OK"
+    fi
+}
+
+createGroupAndUserRedHat() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        groupadd -r gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        useradd --system \
+                --no-create-home \
+                --home-dir /nonexistent \
+                --gid gravitee \
+                --shell /sbin/nologin \
+                --comment "gravitee user" \
+                gravitee
+        echo " OK"
+    fi
+}
+
 err_exit() {
     echo "$@" >&2
     exit 1
@@ -18,54 +92,26 @@ err_exit() {
 case "$1" in
 
     # Debian ####################################################
-    install|upgrade)
-
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            addgroup --quiet --system gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            adduser --quiet \
-                    --system \
-                    --no-create-home \
-                    --home /nonexistent \
-                    --ingroup gravitee \
-                    --disabled-password \
-                    --shell /bin/false \
-                    gravitee
-            echo " OK"
-        fi
+    install)
+        createGroupAndUserDebian
     ;;
+
+    upgrade)
+        checkVersionUpgrade
+        createGroupAndUserDebian
+    ;;
+
     abort-deconfigure|abort-upgrade|abort-remove)
     ;;
 
     # RedHat ####################################################
-    1|2)
+    1)
+        createGroupAndUserRedHat
+    ;;
 
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            groupadd -r gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            useradd --system \
-                    --no-create-home \
-                    --home-dir /nonexistent \
-                    --gid gravitee \
-                    --shell /sbin/nologin \
-                    --comment "gravitee user" \
-                    gravitee
-            echo " OK"
-        fi
+    2)
+        checkVersionUpgrade
+        createGroupAndUserRedHat
     ;;
 
     *)

--- a/apim/3.x/build.sh
+++ b/apim/3.x/build.sh
@@ -52,27 +52,27 @@ build_api_gateway() {
         cp build/files/init.d/graviteeio-apim-gateway ${TEMPLATE_DIR}/etc/init.d
 
 	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-		--rpm-user ${USER} \
-          	--rpm-group ${USER} \
-          	--rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-                --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-gateway" \
-          	--directories /opt/graviteeio \
-        	--before-install build/scripts/gateway/preinst.rpm \
-        	--after-install build/scripts/gateway/postinst.rpm \
-        	--before-remove build/scripts/gateway/prerm.rpm \
-        	--after-remove build/scripts/gateway/postrm.rpm \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-		-s dir -v ${VERSION}  \
-  		--license "${LICENSE}" \
-  		--vendor "${VENDOR}" \
-  		--maintainer "${MAINTAINER}" \
-  		--architecture ${ARCH} \
-  		--url "${URL}" \
-  		--description  "${DESC}: API Gateway" \
-  		--config-files ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-gateway-${VERSION}/config \
-  		--verbose \
-		-n ${PKGNAME}-gateway-3x
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+            --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-gateway" \
+            --directories /opt/graviteeio \
+            --before-install build/scripts/gateway/preinst.rpm \
+            --after-install build/scripts/gateway/postinst.rpm \
+            --before-remove build/scripts/gateway/prerm.rpm \
+            --after-remove build/scripts/gateway/postrm.rpm \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}: API Gateway" \
+            --config-files ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-gateway-${VERSION}/config \
+            --verbose \
+            -n ${PKGNAME}-gateway-3x
 }
 
 build_rest_api() {
@@ -85,31 +85,31 @@ build_rest_api() {
 	mkdir -p ${TEMPLATE_DIR}/etc/systemd/system/
 	cp build/files/systemd/graviteeio-apim-rest-api.service ${TEMPLATE_DIR}/etc/systemd/system/
 
-        mkdir -p ${TEMPLATE_DIR}/etc/init.d
-        cp build/files/init.d/graviteeio-apim-rest-api ${TEMPLATE_DIR}/etc/init.d
+  mkdir -p ${TEMPLATE_DIR}/etc/init.d
+  cp build/files/init.d/graviteeio-apim-rest-api ${TEMPLATE_DIR}/etc/init.d
 
 	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-                --rpm-user ${USER} \
-                --rpm-group ${USER} \
-                --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-                --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-rest-api" \
-                --directories /opt/graviteeio \
-                --before-install build/scripts/rest-api/preinst.rpm \
-                --after-install build/scripts/rest-api/postinst.rpm \
-                --before-remove build/scripts/rest-api/prerm.rpm \
-                --after-remove build/scripts/rest-api/postrm.rpm \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-                -s dir -v ${VERSION}  \
-                --license "${LICENSE}" \
-                --vendor "${VENDOR}" \
-                --maintainer "${MAINTAINER}" \
-                --architecture ${ARCH} \
-                --url "${URL}" \
-                --description  "${DESC}: Management API" \
-                --config-files ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api-${VERSION}/config \
-                --verbose \
-                -n ${PKGNAME}-rest-api-3x
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+            --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-rest-api" \
+            --directories /opt/graviteeio \
+            --before-install build/scripts/rest-api/preinst.rpm \
+            --after-install build/scripts/rest-api/postinst.rpm \
+            --before-remove build/scripts/rest-api/prerm.rpm \
+            --after-remove build/scripts/rest-api/postrm.rpm \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}: Management API" \
+            --config-files ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api-${VERSION}/config \
+            --verbose \
+            -n ${PKGNAME}-rest-api-3x
 }
 
 build_management_ui() {
@@ -123,27 +123,27 @@ build_management_ui() {
 	cp build/files/graviteeio-apim-management-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
 
 	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-                --rpm-user ${USER} \
-                --rpm-group ${USER} \
-                --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-                --directories /opt/graviteeio \
-		--before-install build/scripts/management-ui/preinst.rpm \
-                --after-install build/scripts/management-ui/postinst.rpm \
-                --before-remove build/scripts/management-ui/prerm.rpm \
-                --after-remove build/scripts/management-ui/postrm.rpm \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-                -s dir -v ${VERSION}  \
-                --license "${LICENSE}" \
-                --vendor "${VENDOR}" \
-                --maintainer "${MAINTAINER}" \
-                --architecture ${ARCH} \
-                --url "${URL}" \
-                --description  "${DESC}: Management UI" \
-                --depends nginx \
-		--config-files ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui-${VERSION}/constants.json \
-                --verbose \
-                -n ${PKGNAME}-management-ui-3x
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+            --directories /opt/graviteeio \
+            --before-install build/scripts/management-ui/preinst.rpm \
+            --after-install build/scripts/management-ui/postinst.rpm \
+            --before-remove build/scripts/management-ui/prerm.rpm \
+            --after-remove build/scripts/management-ui/postrm.rpm \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}: Management UI" \
+            --depends nginx \
+            --config-files ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui-${VERSION}/constants.json \
+            --verbose \
+            -n ${PKGNAME}-management-ui-3x
 }
 
 build_portal_ui() {
@@ -161,7 +161,7 @@ build_portal_ui() {
                 --rpm-group ${USER} \
                 --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
                 --directories /opt/graviteeio \
-		--before-install build/scripts/portal-ui/preinst.rpm \
+                --before-install build/scripts/portal-ui/preinst.rpm \
                 --after-install build/scripts/portal-ui/postinst.rpm \
                 --before-remove build/scripts/portal-ui/prerm.rpm \
                 --after-remove build/scripts/portal-ui/postrm.rpm \
@@ -175,7 +175,7 @@ build_portal_ui() {
                 --url "${URL}" \
                 --description  "${DESC}: Portal UI" \
                 --depends nginx \
-		--config-files "${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui-${VERSION}/assets/" \
+		            --config-files "${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui-${VERSION}/assets/" \
                 --verbose \
                 -n ${PKGNAME}-portal-ui-3x
 }
@@ -186,24 +186,24 @@ build_full() {
         mkdir -p ${TEMPLATE_DIR}
 
 	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-                --rpm-user ${USER} \
-                --rpm-group ${USER} \
-                --rpm-attr "0750,${USER},${USER}:/opt/graviteeio" \
-                --iteration ${RELEASE} \
-		-C ${TEMPLATE_DIR} \
-                -s dir -v ${VERSION}  \
-                --license "${LICENSE}" \
-                --vendor "${VENDOR}" \
-                --maintainer "${MAINTAINER}" \
-                --architecture ${ARCH} \
-                --url "${URL}" \
-                --description  "${DESC}" \
-                --depends "${PKGNAME}-portal-ui-3x >= ${VERSION}" \
-                --depends "${PKGNAME}-management-ui-3x >= ${VERSION}" \
-		--depends "${PKGNAME}-rest-api-3x >= ${VERSION}" \
-		--depends "${PKGNAME}-gateway-3x >= ${VERSION}" \
-                --verbose \
-                -n ${PKGNAME}-3x
+            --rpm-user ${USER} \
+            --rpm-group ${USER} \
+            --rpm-attr "0750,${USER},${USER}:/opt/graviteeio" \
+            --iteration ${RELEASE} \
+            -C ${TEMPLATE_DIR} \
+            -s dir -v ${VERSION}  \
+            --license "${LICENSE}" \
+            --vendor "${VENDOR}" \
+            --maintainer "${MAINTAINER}" \
+            --architecture ${ARCH} \
+            --url "${URL}" \
+            --description  "${DESC}" \
+            --depends "${PKGNAME}-portal-ui-3x = ${VERSION}" \
+            --depends "${PKGNAME}-management-ui-3x = ${VERSION}" \
+            --depends "${PKGNAME}-rest-api-3x = ${VERSION}" \
+            --depends "${PKGNAME}-gateway-3x = ${VERSION}" \
+            --verbose \
+            -n ${PKGNAME}-3x
 }
 
 build() {
@@ -212,7 +212,7 @@ build() {
 	build_api_gateway
 	build_rest_api
 	build_management_ui
-        build_portal_ui
+  build_portal_ui
 	build_full
 }
 

--- a/apim/3.x/build/scripts/gateway/preinst.rpm
+++ b/apim/3.x/build/scripts/gateway/preinst.rpm
@@ -10,6 +10,82 @@
 #       $1=1       : indicates a new install
 #       $1=2       : indicates an upgrade
 
+checkVersionUpgrade() {
+    echo "INFO: Some version mismatch issues have been identified in the previous version of this RPM package."
+    echo "INFO: To avoid any destructive changes if the upgrade is applied, some checks on the versions will be ran."
+
+    # Get installedVersion from /opt/graviteeio/apim/graviteeio-apim-gateway-xxxxxxxx
+    installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-gateway-* | cut -d- -f4)
+    # Display installedVersion
+    echo "Installed version: $installedVersion"
+
+    # Parse version based on format x.y.z
+    installedMajor=$(echo $installedVersion | cut -d. -f1)
+    installedMinor=$(echo $installedVersion | cut -d. -f2)
+    installedPatch=$(echo $installedVersion | cut -d. -f3)
+
+    newVersion=%{version}
+    # Display newVersion
+    echo "New version: $newVersion"
+
+    # Parse version based on format x.y.z
+    newVersionMajor=$(echo $newVersion | cut -d. -f1)
+    newVersionMinor=$(echo $newVersion | cut -d. -f2)
+    newVersionPatch=$(echo $newVersion | cut -d. -f3)
+
+    if [ "$installedMajor" -gt "$newVersionMajor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -gt "$newVersionMinor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -eq "$newVersionMinor" -a "$installedPatch" -gt "$newVersionPatch" ] ; then
+        echo "ERROR: You are trying to upgrade to a version ($newVersion) that is lower than the one you are currently running ($installedVersion)"
+        exit 1
+    fi
+}
+
+createGroupAndUserDebian() {
+   # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        addgroup --quiet --system gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        adduser --quiet \
+                --system \
+                --no-create-home \
+                --home /nonexistent \
+                --ingroup gravitee \
+                --disabled-password \
+                --shell /bin/false \
+                gravitee
+        echo " OK"
+    fi
+}
+
+createGroupAndUserRedHat() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        groupadd -r gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        useradd --system \
+                --no-create-home \
+                --home-dir /nonexistent \
+                --gid gravitee \
+                --shell /sbin/nologin \
+                --comment "gravitee user" \
+                gravitee
+        echo " OK"
+    fi
+}
+
 err_exit() {
     echo "$@" >&2
     exit 1
@@ -18,54 +94,26 @@ err_exit() {
 case "$1" in
 
     # Debian ####################################################
-    install|upgrade)
-
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            addgroup --quiet --system gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            adduser --quiet \
-                    --system \
-                    --no-create-home \
-                    --home /nonexistent \
-                    --ingroup gravitee \
-                    --disabled-password \
-                    --shell /bin/false \
-                    gravitee
-            echo " OK"
-        fi
+    install)
+        createGroupAndUserDebian
     ;;
+
+    upgrade)
+        checkVersionUpgrade
+        createGroupAndUserDebian
+    ;;
+
     abort-deconfigure|abort-upgrade|abort-remove)
     ;;
 
     # RedHat ####################################################
-    1|2)
+    1)
+        createGroupAndUserRedHat
+    ;;
 
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            groupadd -r gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            useradd --system \
-                    --no-create-home \
-                    --home-dir /nonexistent \
-                    --gid gravitee \
-                    --shell /sbin/nologin \
-                    --comment "gravitee user" \
-                    gravitee
-            echo " OK"
-        fi
+    2)
+        checkVersionUpgrade
+        createGroupAndUserRedHat
     ;;
 
     *)

--- a/apim/3.x/build/scripts/management-ui/preinst.rpm
+++ b/apim/3.x/build/scripts/management-ui/preinst.rpm
@@ -10,6 +10,82 @@
 #       $1=1       : indicates a new install
 #       $1=2       : indicates an upgrade
 
+checkVersionUpgrade() {
+    echo "INFO: Some version mismatch issues have been identified in the previous version of this RPM package."
+    echo "INFO: To avoid any destructive changes if the upgrade is applied, some checks on the versions will be ran."
+
+    # Get installedVersion from /opt/graviteeio/apim/graviteeio-apim-console-ui-xxxxxxxx
+    installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-console-ui-* | cut -d- -f5)
+    # Display installedVersion
+    echo "Installed version: $installedVersion"
+
+    # Parse version based on format x.y.z
+    installedMajor=$(echo $installedVersion | cut -d. -f1)
+    installedMinor=$(echo $installedVersion | cut -d. -f2)
+    installedPatch=$(echo $installedVersion | cut -d. -f3)
+
+    newVersion=%{version}
+    # Display newVersion
+    echo "New version: $newVersion"
+
+    # Parse version based on format x.y.z
+    newVersionMajor=$(echo $newVersion | cut -d. -f1)
+    newVersionMinor=$(echo $newVersion | cut -d. -f2)
+    newVersionPatch=$(echo $newVersion | cut -d. -f3)
+
+    if [ "$installedMajor" -gt "$newVersionMajor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -gt "$newVersionMinor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -eq "$newVersionMinor" -a "$installedPatch" -gt "$newVersionPatch" ] ; then
+        echo "ERROR: You are trying to upgrade to a version ($newVersion) that is lower than the one you are currently running ($installedVersion)"
+        exit 1
+    fi
+}
+
+createGroupAndUserDebian() {
+   # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        addgroup --quiet --system gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        adduser --quiet \
+                --system \
+                --no-create-home \
+                --home /nonexistent \
+                --ingroup gravitee \
+                --disabled-password \
+                --shell /bin/false \
+                gravitee
+        echo " OK"
+    fi
+}
+
+createGroupAndUserRedHat() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        groupadd -r gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        useradd --system \
+                --no-create-home \
+                --home-dir /nonexistent \
+                --gid gravitee \
+                --shell /sbin/nologin \
+                --comment "gravitee user" \
+                gravitee
+        echo " OK"
+    fi
+}
+
 err_exit() {
     echo "$@" >&2
     exit 1
@@ -18,54 +94,26 @@ err_exit() {
 case "$1" in
 
     # Debian ####################################################
-    install|upgrade)
-
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            addgroup --quiet --system gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            adduser --quiet \
-                    --system \
-                    --no-create-home \
-                    --home /nonexistent \
-                    --ingroup gravitee \
-                    --disabled-password \
-                    --shell /bin/false \
-                    gravitee
-            echo " OK"
-        fi
+    install)
+        createGroupAndUserDebian
     ;;
+
+    upgrade)
+        checkVersionUpgrade
+        createGroupAndUserDebian
+    ;;
+
     abort-deconfigure|abort-upgrade|abort-remove)
     ;;
 
     # RedHat ####################################################
-    1|2)
+    1)
+        createGroupAndUserRedHat
+    ;;
 
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            groupadd -r gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            useradd --system \
-                    --no-create-home \
-                    --home-dir /nonexistent \
-                    --gid gravitee \
-                    --shell /sbin/nologin \
-                    --comment "gravitee user" \
-                    gravitee
-            echo " OK"
-        fi
+    2)
+        checkVersionUpgrade
+        createGroupAndUserRedHat
     ;;
 
     *)

--- a/apim/3.x/build/scripts/portal-ui/preinst.rpm
+++ b/apim/3.x/build/scripts/portal-ui/preinst.rpm
@@ -10,6 +10,82 @@
 #       $1=1       : indicates a new install
 #       $1=2       : indicates an upgrade
 
+checkVersionUpgrade() {
+    echo "INFO: Some version mismatch issues have been identified in the previous version of this RPM package."
+    echo "INFO: To avoid any destructive changes if the upgrade is applied, some checks on the versions will be ran."
+
+    # Get installedVersion from /opt/graviteeio/apim/graviteeio-apim-portal-ui-xxxxxxxx
+    installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-portal-ui-* | cut -d- -f5)
+    # Display installedVersion
+    echo "Installed version: $installedVersion"
+
+    # Parse version based on format x.y.z
+    installedMajor=$(echo $installedVersion | cut -d. -f1)
+    installedMinor=$(echo $installedVersion | cut -d. -f2)
+    installedPatch=$(echo $installedVersion | cut -d. -f3)
+
+    newVersion=%{version}
+    # Display newVersion
+    echo "New version: $newVersion"
+
+    # Parse version based on format x.y.z
+    newVersionMajor=$(echo $newVersion | cut -d. -f1)
+    newVersionMinor=$(echo $newVersion | cut -d. -f2)
+    newVersionPatch=$(echo $newVersion | cut -d. -f3)
+
+    if [ "$installedMajor" -gt "$newVersionMajor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -gt "$newVersionMinor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -eq "$newVersionMinor" -a "$installedPatch" -gt "$newVersionPatch" ] ; then
+        echo "ERROR: You are trying to upgrade to a version ($newVersion) that is lower than the one you are currently running ($installedVersion)"
+        exit 1
+    fi
+}
+
+createGroupAndUserDebian() {
+   # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        addgroup --quiet --system gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        adduser --quiet \
+                --system \
+                --no-create-home \
+                --home /nonexistent \
+                --ingroup gravitee \
+                --disabled-password \
+                --shell /bin/false \
+                gravitee
+        echo " OK"
+    fi
+}
+
+createGroupAndUserRedHat() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        groupadd -r gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        useradd --system \
+                --no-create-home \
+                --home-dir /nonexistent \
+                --gid gravitee \
+                --shell /sbin/nologin \
+                --comment "gravitee user" \
+                gravitee
+        echo " OK"
+    fi
+}
+
 err_exit() {
     echo "$@" >&2
     exit 1
@@ -18,54 +94,26 @@ err_exit() {
 case "$1" in
 
     # Debian ####################################################
-    install|upgrade)
-
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            addgroup --quiet --system gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            adduser --quiet \
-                    --system \
-                    --no-create-home \
-                    --home /nonexistent \
-                    --ingroup gravitee \
-                    --disabled-password \
-                    --shell /bin/false \
-                    gravitee
-            echo " OK"
-        fi
+    install)
+        createGroupAndUserDebian
     ;;
+
+    upgrade)
+        checkVersionUpgrade
+        createGroupAndUserDebian
+    ;;
+
     abort-deconfigure|abort-upgrade|abort-remove)
     ;;
 
     # RedHat ####################################################
-    1|2)
+    1)
+        createGroupAndUserRedHat
+    ;;
 
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            groupadd -r gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            useradd --system \
-                    --no-create-home \
-                    --home-dir /nonexistent \
-                    --gid gravitee \
-                    --shell /sbin/nologin \
-                    --comment "gravitee user" \
-                    gravitee
-            echo " OK"
-        fi
+    2)
+        checkVersionUpgrade
+        createGroupAndUserRedHat
     ;;
 
     *)

--- a/apim/3.x/build/scripts/rest-api/preinst.rpm
+++ b/apim/3.x/build/scripts/rest-api/preinst.rpm
@@ -10,6 +10,82 @@
 #       $1=1       : indicates a new install
 #       $1=2       : indicates an upgrade
 
+checkVersionUpgrade() {
+    echo "INFO: Some version mismatch issues have been identified in the previous version of this RPM package."
+    echo "INFO: To avoid any destructive changes if the upgrade is applied, some checks on the versions will be ran."
+
+    # Get installedVersion from /opt/graviteeio/apim/graviteeio-apim-rest-api-xxxxxxxx
+    installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-rest-api-* | cut -d- -f5)
+    # Display installedVersion
+    echo "Installed version: $installedVersion"
+
+    # Parse version based on format x.y.z
+    installedMajor=$(echo $installedVersion | cut -d. -f1)
+    installedMinor=$(echo $installedVersion | cut -d. -f2)
+    installedPatch=$(echo $installedVersion | cut -d. -f3)
+
+    newVersion=%{version}
+    # Display newVersion
+    echo "New version: $newVersion"
+
+    # Parse version based on format x.y.z
+    newVersionMajor=$(echo $newVersion | cut -d. -f1)
+    newVersionMinor=$(echo $newVersion | cut -d. -f2)
+    newVersionPatch=$(echo $newVersion | cut -d. -f3)
+
+    if [ "$installedMajor" -gt "$newVersionMajor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -gt "$newVersionMinor" ] || \
+       [ "$installedMajor" -eq "$newVersionMajor" -a "$installedMinor" -eq "$newVersionMinor" -a "$installedPatch" -gt "$newVersionPatch" ] ; then
+        echo "ERROR: You are trying to upgrade to a version ($newVersion) that is lower than the one you are currently running ($installedVersion)"
+        exit 1
+    fi
+}
+
+createGroupAndUserDebian() {
+   # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        addgroup --quiet --system gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        adduser --quiet \
+                --system \
+                --no-create-home \
+                --home /nonexistent \
+                --ingroup gravitee \
+                --disabled-password \
+                --shell /bin/false \
+                gravitee
+        echo " OK"
+    fi
+}
+
+createGroupAndUserRedHat() {
+    # Create gravitee group if not existing
+    if ! getent group gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee group..."
+        groupadd -r gravitee
+        echo " OK"
+    fi
+
+    # Create gravitee user if not existing
+    if ! id gravitee > /dev/null 2>&1 ; then
+        echo -n "Creating gravitee user..."
+        useradd --system \
+                --no-create-home \
+                --home-dir /nonexistent \
+                --gid gravitee \
+                --shell /sbin/nologin \
+                --comment "gravitee user" \
+                gravitee
+        echo " OK"
+    fi
+}
+
 err_exit() {
     echo "$@" >&2
     exit 1
@@ -18,54 +94,26 @@ err_exit() {
 case "$1" in
 
     # Debian ####################################################
-    install|upgrade)
-
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            addgroup --quiet --system gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            adduser --quiet \
-                    --system \
-                    --no-create-home \
-                    --home /nonexistent \
-                    --ingroup gravitee \
-                    --disabled-password \
-                    --shell /bin/false \
-                    gravitee
-            echo " OK"
-        fi
+    install)
+        createGroupAndUserDebian
     ;;
+
+    upgrade)
+        checkVersionUpgrade
+        createGroupAndUserDebian
+    ;;
+
     abort-deconfigure|abort-upgrade|abort-remove)
     ;;
 
     # RedHat ####################################################
-    1|2)
+    1)
+        createGroupAndUserRedHat
+    ;;
 
-        # Create gravitee group if not existing
-        if ! getent group gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee group..."
-            groupadd -r gravitee
-            echo " OK"
-        fi
-
-        # Create gravitee user if not existing
-        if ! id gravitee > /dev/null 2>&1 ; then
-            echo -n "Creating gravitee user..."
-            useradd --system \
-                    --no-create-home \
-                    --home-dir /nonexistent \
-                    --gid gravitee \
-                    --shell /sbin/nologin \
-                    --comment "gravitee user" \
-                    gravitee
-            echo " OK"
-        fi
+    2)
+        checkVersionUpgrade
+        createGroupAndUserRedHat
     ;;
 
     *)


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7484

## Description

Having a `>=` is causing troubles as for instance it leads to downloading components 3.17.0 when you try to install
the 3.15.6 full bundle. 

This PR:

1. Use a strict `=` reference in the full bundle
2. Add some checks in the preinstall script to avoid any automatic and unwanted downgrade when users will update their installation with the next released version that will contain that fix.

## To test

### CentOS

Build the RPMs using` build.sh`:

```shell
cd apim/3.x
./build.sh -v 3.15.6
```

Run centos docker container with a volume mount:
```shell
export PATH_TO_LOCAL_RPMS=$(pwd)
docker run --rm -v ${PATH_TO_LOCAL_RPMS}:/local-rpms -it --entrypoint bash centos
```

Inside the container:
```shell
# Add packagecloud registry to be able to run install APIM
echo "[graviteeio]
name=graviteeio
baseurl=https://packagecloud.io/graviteeio/rpms/el/7/\$basearch
gpgcheck=0
enabled=1
gpgkey=https://packagecloud.io/graviteeio/rpms/gpgkey
sslverify=1
sslcacert=/etc/pki/tls/certs/ca-bundle.crt
metadata_expire=300" > /etc/yum.repos.d/graviteeio.repo

# Some dark magic to have everything related to repo working properly on my local docker container
cd /etc/yum.repos.d/
sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
yum install pygpgme yum-utils
yum update -y
yum -q makecache -y --disablerepo='*' --enablerepo='graviteeio'

# Install APIM 3.15.0, or in reality 3.17.1 :p
yum install graviteeio-apim-3x-3.15.0-0.noarch -y

# Try to install fixed version of the packages
yum install /local-rpms/graviteeio-apim-gateway-3x-3.15.6-0.noarch.rpm
yum install /local-rpms/graviteeio-apim-management-ui-3x-3.15.6-0.noarch.rpm
yum install /local-rpms/graviteeio-apim-portal-ui-3x-3.15.6-0.noarch.rpm
yum install /local-rpms/graviteeio-apim-rest-api-3x-3.15.6-0.noarch.rpm
```

All the 4 last lines (trying to install local packages) should fail with the following message:
![image](https://user-images.githubusercontent.com/4112568/163580448-fe59e67a-1b36-4a6b-a8ff-ed8c01e031c4.png)

To check everything is ok when upgrading run:

```shell
# Downgrade to 3.15.0
yum install graviteeio-apim-gateway-3x-3.15.0
# Upgrade to 3.15.6
yum install /local-rpms/graviteeio-apim-gateway-3x-3.15.6-0.noarch.rpm

yum install graviteeio-apim-management-ui-3x-3.15.0
yum install /local-rpms/graviteeio-apim-management-ui-3x-3.15.6-0.noarch.rpm

yum install graviteeio-apim-portal-ui-3x-3.15.0
yum install /local-rpms/graviteeio-apim-portal-ui-3x-3.15.6-0.noarch.rpm

yum install graviteeio-apim-rest-api-3x-3.15.0
yum install /local-rpms/graviteeio-apim-rest-api-3x-3.15.6-0.noarch.rpm
```

Finally to test a fresh install:
```shell
# Remove 
yum remove graviteeio-apim-gateway-3x
# Install local 3.15.6
yum install /local-rpms/graviteeio-apim-gateway-3x-3.15.6-0.noarch.rpm

yum remove graviteeio-apim-management-ui-3x
yum install /local-rpms/graviteeio-apim-management-ui-3x-3.15.6-0.noarch.rpm

yum remove graviteeio-apim-portal-ui-3x
yum install /local-rpms/graviteeio-apim-portal-ui-3x-3.15.6-0.noarch.rpm

yum remove graviteeio-apim-rest-api-3x
yum install /local-rpms/graviteeio-apim-rest-api-3x-3.15.6-0.noarch.rpm
```


### RedHat

To test the fix on RedHat just follow the CentOS section with a redhat ubi docker image:

```shell
docker run --rm -v ${PATH_TO_LOCAL_RPMS}:/local-rpms -it --entrypoint bash redhat/ubi8
```

### Debian

⚠️ There are some references to Debian in the code BUT there is absolutely nothing about Debian installation in docs.gravitee.io so I'm not sure what to do/test with it.

### AM

To test the AM RPMs follow the CentOS section and replace APIM package by `graviteeio-am-3x-3.15.0-0.noarch`


