### PR TITLE
cicd: adding devops as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Default
 
 *                                                            @gravitee-io/techops
+*                                                            @gravitee-io/devops
 
 /apim/                                                       @gravitee-io/apim
 /am/                                                         @gravitee-io/am


### PR DESCRIPTION
this PR is created in order to add devops team as codeowners