### PR TITLE
fix: keep previous configuration on upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd apim/4.x
 Run CentOS docker container with a volume mount:
 ```shell
 export PATH_TO_LOCAL_RPMS=$(pwd)
-docker run --rm -v ${PATH_TO_LOCAL_RPMS}:/local-rpms -it --entrypoint bash centos
+docker run --rm -v ${PATH_TO_LOCAL_RPMS}:/local-rpms -it --entrypoint bash centos:7
 ```
 
 ### Determine the tag to use
@@ -77,3 +77,79 @@ yum -q makecache -y --disablerepo='*' --enablerepo='graviteeio'
 # Install RPMs
 yum install graviteeio-apim-4x-[TAG].noarch -y
 ```
+
+## Manual Integration test
+
+### Process to test an APIM upgrade
+
+1. provision a VM with Redhat RHEL 8.5 or 9
+
+2. On your laptop, build rpm locally for 2 versions:
+```bash
+cd apim/3.x
+mkdir -p rpms/3.20.{9,21}
+
+[ -d .staging ] && rm -rf .staging
+./build.sh -v 3.20.9
+rm -f graviteeio-apim-3x-*.rpm   # as we install each rpm manually, we do not use the global rpm.
+mv graviteeio-apim-*.rpm rpms/3.20.9/
+
+[ -d .staging ] && rm -rf .staging
+./build.sh -v 3.20.21
+rm -f graviteeio-apim-3x-*.rpm   # as we install each rpm manually, we do not use the global rpm.
+mv graviteeio-apim-*.rpm rpms/3.20.21/
+```
+
+3. Connect via ssh to your VM and enable port forwarding to be able to test connexion on APIM
+```bash
+ssh -i key.pem \
+    -o UserKnownHostsFile=/dev/null \
+    -o StrictHostKeyChecking=no \
+    -L localhost:8082:localhost:8082 \
+    -L localhost:8083:localhost:8083 \
+    -L localhost:8084:localhost:8084 \
+    -L localhost:8085:localhost:8085 \
+    gravitee@192.168.0.253
+```
+
+4. install all prerequities without gravitee (to not install the latest version)
+```bash
+curl -L https://raw.githubusercontent.com/gravitee-io/scripts/master/apim/3.x/redhat/install_redhat.sh | sed '/main()/,/}/{/install_graviteeio/d}' | bash
+```
+
+5. copy the rpms folder into your VM (from your laptop)
+```bash
+scp -r -i key.pem -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no rpms gravitee@192.168.0.253:.
+```
+Note: we use here our own private key `key.pem`, do not add this ssh info on our local config, use our user `gravitee` on the VM with IP `192.168.0.253`.
+
+6. into the VM install the first rpms and then start services
+```bash
+cd ~/rpms/3.20.9
+for rpm in graviteeio-apim-*.rpm; do sudo yum install -y "${rpm}"; done
+sudo systemctl start nginx.service graviteeio-apim-rest-api.service graviteeio-apim-gateway.service
+```
+
+7. in another terminal, you can check which version of APIM is answering (Note you can install and use `tmux`):
+```bash
+while true; do echo "$(date)    $(curl -s -u 'admin:adminadmin' 'http://localhost:18083/_node' | jq -r '.version.MAJOR_VERSION')"; sleep 1; done
+```
+
+8. update rest-api config file to add another admin user and restart service to use it:
+```bash
+sed '/^security:/,/^ *# Enable authentication/{/username: application1/,/#email:/{s/#email:/#email:\n        - user:\n          username: gravitee\n          #firstname:\n          #lastname:\n          # Password value: bloubiboulga\n          password: $2a$10$iJmJIgf7\/Y14AtR\/lKkyzeX5cyL5nL4lgePjiBVvRkq4m652E70oy\n          roles: ORGANIZATION:ADMIN,ENVIRONMENT:ADMIN\n          #email:/}}' /opt/graviteeio/apim/rest-api/config/gravitee.yml
+
+sudo systemctl restart graviteeio-apim-rest-api.service
+```
+Note: the command used to generate the password is: `htpasswd -bnBC 10 "" bloubiboulga | tr -d ':\n' | sed 's/^$2y\$/$2a$/'`
+
+9. Connect into APIM on http://localhost:8084 with new created user/pass: `gravitee/bloubiboulga`
+
+10. Now in the VM, we want to upgrade to 3.20.21 without loosing configuration
+```bash
+cd ~/rpms/3.20.21
+for rpm in graviteeio-apim-*.rpm; do sudo yum upgrade -y "${rpm}"; done
+sudo systemctl start nginx.service graviteeio-apim-rest-api.service graviteeio-apim-gateway.service
+```
+
+11. We should be able to connect on http://localhost:8084 always with user `gravitee`. The curl command to show the version should answer `3.20.21`

--- a/apim/3.x/build.sh
+++ b/apim/3.x/build.sh
@@ -19,244 +19,243 @@ declare DESC="Gravitee.io API Management 3.x"
 declare MAINTAINER="David BRASSELY <david.brassely@graviteesource.com>"
 declare DOCKER_WDIR="/tmp/fpm"
 declare DOCKER_FPM="graviteeio/fpm"
-declare TEMPLATE_DIR="";
+declare TEMPLATE_DIR=""
 
 parse_version() {
-    declare GRAVITEEIO_QUALIFIER=""
+  declare GRAVITEEIO_QUALIFIER=""
 
-    # parse version to determine if it is a pre release or not
-    # More information about the versioning here:
-    #  - https://fedoraproject.org/wiki/Package_Versioning_Examples
-    #  - https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_prerelease_versions
+  # parse version to determine if it is a pre release or not
+  # More information about the versioning here:
+  #  - https://fedoraproject.org/wiki/Package_Versioning_Examples
+  #  - https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_prerelease_versions
 
-    VERSION=$(echo "$VERSION_WITH_QUALIFIER" | awk -F '-' '{print $1}')    # 3.19.0
+  VERSION=$(echo "$VERSION_WITH_QUALIFIER" | awk -F '-' '{print $1}') # 3.19.0
 
-    GRAVITEEIO_QUALIFIER=$(echo "$VERSION_WITH_QUALIFIER" | awk -F '-' '{print $2}')  # alpha.1 or empty
-    if [ -n "$GRAVITEEIO_QUALIFIER" ]; then
-      declare GRAVITEEIO_QUALIFIER_NAME=""
-      declare GRAVITEEIO_QUALIFIER_VERSION=""
+  GRAVITEEIO_QUALIFIER=$(echo "$VERSION_WITH_QUALIFIER" | awk -F '-' '{print $2}') # alpha.1 or empty
+  if [ -n "$GRAVITEEIO_QUALIFIER" ]; then
+    declare GRAVITEEIO_QUALIFIER_NAME=""
+    declare GRAVITEEIO_QUALIFIER_VERSION=""
 
-      GRAVITEEIO_QUALIFIER_NAME=$(echo "$GRAVITEEIO_QUALIFIER" | awk -F '.' '{print $1}')          # alpha or empty
-      GRAVITEEIO_QUALIFIER_VERSION=$(echo "$GRAVITEEIO_QUALIFIER" | awk -F '.' '{print $2}')       # 1  or empty
+    GRAVITEEIO_QUALIFIER_NAME=$(echo "$GRAVITEEIO_QUALIFIER" | awk -F '.' '{print $1}')    # alpha or empty
+    GRAVITEEIO_QUALIFIER_VERSION=$(echo "$GRAVITEEIO_QUALIFIER" | awk -F '.' '{print $2}') # 1  or empty
 
-      # If there is a qualifier, it means that the version is a pre-release. So according to the documentation, release must be a number < 1 and of the form "0.x"
-      RELEASE="0.$GRAVITEEIO_QUALIFIER_VERSION.$GRAVITEEIO_QUALIFIER_NAME"
-    else
-      # If there is no qualifier, it means that the version is a final release. So according to the documentation, release must be a number >= 1
-      RELEASE="1"
-    fi
+    # If there is a qualifier, it means that the version is a pre-release. So according to the documentation, release must be a number < 1 and of the form "0.x"
+    RELEASE="0.$GRAVITEEIO_QUALIFIER_VERSION.$GRAVITEEIO_QUALIFIER_NAME"
+  else
+    # If there is no qualifier, it means that the version is a final release. So according to the documentation, release must be a number >= 1
+    RELEASE="1"
+  fi
 }
 
-
 clean() {
-	rm -rf build/skel/*
-	rm -f *.deb
-	rm -f *.rpm
-	rm -f *.tar.gz
+  rm -rf build/skel/*
+  rm -f *.deb
+  rm -f *.rpm
+  rm -f *.tar.gz
 }
 
 # Download bundle
 download() {
-	local filename="graviteeio-full-${VERSION_WITH_QUALIFIER}.zip"
-	rm -fr .staging
-	mkdir .staging
-	wget --progress=bar:force -P .staging https://download.gravitee.io/graviteeio-apim/distributions/${filename}
-	wget -nv -P .staging "https://download.gravitee.io/graviteeio-apim/distributions/${filename}.sha1"
-	cd .staging ; sha1sum -c ${filename}.sha1 ; unzip ${filename} ; rm ${filename} ; rm ${filename}.sha1 ; cd ..
+  local filename="graviteeio-full-${VERSION_WITH_QUALIFIER}.zip"
+  rm -fr .staging
+  mkdir .staging
+  wget --progress=bar:force -P .staging https://download.gravitee.io/graviteeio-apim/distributions/${filename}
+  wget -nv -P .staging "https://download.gravitee.io/graviteeio-apim/distributions/${filename}.sha1"
+  cd .staging
+  sha1sum -c ${filename}.sha1
+  unzip ${filename}
+  rm ${filename}
+  rm ${filename}.sha1
+  cd ..
 }
 
 # Prepare API Gateway packaging
 build_api_gateway() {
-	rm -fr build/skel/
+  rm -fr build/skel/
 
-	mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-	cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-	ln -sf build/skel/el7/opt/graviteeio/apim/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/gateway
+  mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-gateway
+  ln -sf build/skel/el7/opt/graviteeio/apim/graviteeio-apim-gateway ${TEMPLATE_DIR}/opt/graviteeio/apim/gateway
+  mkdir -p ${TEMPLATE_DIR}/etc/systemd/system/
+  cp build/files/systemd/graviteeio-apim-gateway.service ${TEMPLATE_DIR}/etc/systemd/system/
 
-	mkdir -p ${TEMPLATE_DIR}/etc/systemd/system/
-        cp build/files/systemd/graviteeio-apim-gateway.service ${TEMPLATE_DIR}/etc/systemd/system/
+  mkdir -p ${TEMPLATE_DIR}/etc/init.d
+  cp build/files/init.d/graviteeio-apim-gateway ${TEMPLATE_DIR}/etc/init.d
 
-        mkdir -p ${TEMPLATE_DIR}/etc/init.d
-        cp build/files/init.d/graviteeio-apim-gateway ${TEMPLATE_DIR}/etc/init.d
-
-	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-            --rpm-user ${USER} \
-            --rpm-group ${USER} \
-            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-            --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-gateway" \
-            --directories /opt/graviteeio \
-            --before-install build/scripts/gateway/preinst.rpm \
-            --after-install build/scripts/gateway/postinst.rpm \
-            --before-remove build/scripts/gateway/prerm.rpm \
-            --after-remove build/scripts/gateway/postrm.rpm \
-            --iteration ${RELEASE} \
-            -C ${TEMPLATE_DIR} \
-            -s dir -v ${VERSION}  \
-            --license "${LICENSE}" \
-            --vendor "${VENDOR}" \
-            --maintainer "${MAINTAINER}" \
-            --architecture ${ARCH} \
-            --url "${URL}" \
-            --description  "${DESC}: API Gateway" \
-            --config-files /opt/graviteeio/apim/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER}/config \
-            --verbose \
-            -n ${PKGNAME}-gateway-3x
+  docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
+    --rpm-user ${USER} \
+    --rpm-group ${USER} \
+    --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+    --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-gateway" \
+    --directories /opt/graviteeio \
+    --before-install build/scripts/gateway/preinst.rpm \
+    --after-install build/scripts/gateway/postinst.rpm \
+    --before-remove build/scripts/gateway/prerm.rpm \
+    --after-remove build/scripts/gateway/postrm.rpm \
+    --iteration ${RELEASE} \
+    -C ${TEMPLATE_DIR} \
+    -s dir -v ${VERSION} \
+    --license "${LICENSE}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --architecture ${ARCH} \
+    --url "${URL}" \
+    --description "${DESC}: API Gateway" \
+    --config-files /opt/graviteeio/apim/graviteeio-apim-gateway/config \
+    --verbose \
+    -n ${PKGNAME}-gateway-3x
 }
 
 build_rest_api() {
-	rm -fr build/skel/
-	
-	mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-        cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-	ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/rest-api
+  rm -fr build/skel/
 
-	mkdir -p ${TEMPLATE_DIR}/etc/systemd/system/
-	cp build/files/systemd/graviteeio-apim-rest-api.service ${TEMPLATE_DIR}/etc/systemd/system/
+  mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api
+  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api ${TEMPLATE_DIR}/opt/graviteeio/apim/rest-api
+  mkdir -p ${TEMPLATE_DIR}/etc/systemd/system/
+  cp build/files/systemd/graviteeio-apim-rest-api.service ${TEMPLATE_DIR}/etc/systemd/system/
 
   mkdir -p ${TEMPLATE_DIR}/etc/init.d
   cp build/files/init.d/graviteeio-apim-rest-api ${TEMPLATE_DIR}/etc/init.d
 
-	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-            --rpm-user ${USER} \
-            --rpm-group ${USER} \
-            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-            --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-rest-api" \
-            --directories /opt/graviteeio \
-            --before-install build/scripts/rest-api/preinst.rpm \
-            --after-install build/scripts/rest-api/postinst.rpm \
-            --before-remove build/scripts/rest-api/prerm.rpm \
-            --after-remove build/scripts/rest-api/postrm.rpm \
-            --iteration ${RELEASE} \
-            -C ${TEMPLATE_DIR} \
-            -s dir -v ${VERSION}  \
-            --license "${LICENSE}" \
-            --vendor "${VENDOR}" \
-            --maintainer "${MAINTAINER}" \
-            --architecture ${ARCH} \
-            --url "${URL}" \
-            --description  "${DESC}: Management API" \
-            --config-files /opt/graviteeio/apim/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER}/config \
-            --verbose \
-            -n ${PKGNAME}-rest-api-3x
+  docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
+    --rpm-user ${USER} \
+    --rpm-group ${USER} \
+    --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+    --rpm-attr "0755,root,root:/etc/init.d/graviteeio-apim-rest-api" \
+    --directories /opt/graviteeio \
+    --before-install build/scripts/rest-api/preinst.rpm \
+    --after-install build/scripts/rest-api/postinst.rpm \
+    --before-remove build/scripts/rest-api/prerm.rpm \
+    --after-remove build/scripts/rest-api/postrm.rpm \
+    --iteration ${RELEASE} \
+    -C ${TEMPLATE_DIR} \
+    -s dir -v ${VERSION} \
+    --license "${LICENSE}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --architecture ${ARCH} \
+    --url "${URL}" \
+    --description "${DESC}: Management API" \
+    --config-files /opt/graviteeio/apim/graviteeio-apim-rest-api/config \
+    --verbose \
+    -n ${PKGNAME}-rest-api-3x
 }
 
 build_management_ui() {
-	rm -fr build/skel/
+  rm -fr build/skel/
 
-	mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-        cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-	ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/management-ui
+  mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui
+  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui ${TEMPLATE_DIR}/opt/graviteeio/apim/management-ui
+  mkdir -p ${TEMPLATE_DIR}/etc/nginx/conf.d/
+  cp build/files/graviteeio-apim-management-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
 
-	mkdir -p ${TEMPLATE_DIR}/etc/nginx/conf.d/
-	cp build/files/graviteeio-apim-management-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
-
-	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-            --rpm-user ${USER} \
-            --rpm-group ${USER} \
-            --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-            --directories /opt/graviteeio \
-            --before-install build/scripts/management-ui/preinst.rpm \
-            --after-install build/scripts/management-ui/postinst.rpm \
-            --before-remove build/scripts/management-ui/prerm.rpm \
-            --after-remove build/scripts/management-ui/postrm.rpm \
-            --iteration ${RELEASE} \
-            -C ${TEMPLATE_DIR} \
-            -s dir -v ${VERSION}  \
-            --license "${LICENSE}" \
-            --vendor "${VENDOR}" \
-            --maintainer "${MAINTAINER}" \
-            --architecture ${ARCH} \
-            --url "${URL}" \
-            --description  "${DESC}: Management UI" \
-            --depends nginx \
-            --config-files /opt/graviteeio/apim/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER}/constants.json \
-            --verbose \
-            -n ${PKGNAME}-management-ui-3x
+  docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
+    --rpm-user ${USER} \
+    --rpm-group ${USER} \
+    --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+    --directories /opt/graviteeio \
+    --before-install build/scripts/management-ui/preinst.rpm \
+    --after-install build/scripts/management-ui/postinst.rpm \
+    --before-remove build/scripts/management-ui/prerm.rpm \
+    --after-remove build/scripts/management-ui/postrm.rpm \
+    --iteration ${RELEASE} \
+    -C ${TEMPLATE_DIR} \
+    -s dir -v ${VERSION} \
+    --license "${LICENSE}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --architecture ${ARCH} \
+    --url "${URL}" \
+    --description "${DESC}: Management UI" \
+    --depends nginx \
+    --config-files /opt/graviteeio/apim/graviteeio-apim-console-ui/constants.json \
+    --verbose \
+    -n ${PKGNAME}-management-ui-3x
 }
 
 build_portal_ui() {
-	rm -fr build/skel/
+  rm -fr build/skel/
 
-	mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-        cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-	ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/portal-ui
+  mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui
+  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui ${TEMPLATE_DIR}/opt/graviteeio/apim/portal-ui
+  mkdir -p ${TEMPLATE_DIR}/etc/nginx/conf.d/
+  cp build/files/graviteeio-apim-portal-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
 
-	mkdir -p ${TEMPLATE_DIR}/etc/nginx/conf.d/
-	cp build/files/graviteeio-apim-portal-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
-
-	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-                --rpm-user ${USER} \
-                --rpm-group ${USER} \
-                --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
-                --directories /opt/graviteeio \
-                --before-install build/scripts/portal-ui/preinst.rpm \
-                --after-install build/scripts/portal-ui/postinst.rpm \
-                --before-remove build/scripts/portal-ui/prerm.rpm \
-                --after-remove build/scripts/portal-ui/postrm.rpm \
-                --iteration ${RELEASE} \
-                -C ${TEMPLATE_DIR} \
-                -s dir -v ${VERSION}  \
-                --license "${LICENSE}" \
-                --vendor "${VENDOR}" \
-                --maintainer "${MAINTAINER}" \
-                --architecture ${ARCH} \
-                --url "${URL}" \
-                --description  "${DESC}: Portal UI" \
-                --depends nginx \
-		            --config-files "${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER}/assets/" \
-                --verbose \
-                -n ${PKGNAME}-portal-ui-3x
+  docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
+    --rpm-user ${USER} \
+    --rpm-group ${USER} \
+    --rpm-attr "0755,${USER},${USER}:/opt/graviteeio" \
+    --directories /opt/graviteeio \
+    --before-install build/scripts/portal-ui/preinst.rpm \
+    --after-install build/scripts/portal-ui/postinst.rpm \
+    --before-remove build/scripts/portal-ui/prerm.rpm \
+    --after-remove build/scripts/portal-ui/postrm.rpm \
+    --iteration ${RELEASE} \
+    -C ${TEMPLATE_DIR} \
+    -s dir -v ${VERSION} \
+    --license "${LICENSE}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --architecture ${ARCH} \
+    --url "${URL}" \
+    --description "${DESC}: Portal UI" \
+    --depends nginx \
+    --config-files "${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui/assets/" \
+    --verbose \
+    -n ${PKGNAME}-portal-ui-3x
 }
 
 build_full() {
-	# Dirty hack to avoid issues with FPM
-	rm -fr build/skel/
-        mkdir -p ${TEMPLATE_DIR}
+  # Dirty hack to avoid issues with FPM
+  rm -fr build/skel/
+  mkdir -p ${TEMPLATE_DIR}
 
-	docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
-            --rpm-user ${USER} \
-            --rpm-group ${USER} \
-            --rpm-attr "0750,${USER},${USER}:/opt/graviteeio" \
-            --iteration ${RELEASE} \
-            -C ${TEMPLATE_DIR} \
-            -s dir -v ${VERSION}  \
-            --license "${LICENSE}" \
-            --vendor "${VENDOR}" \
-            --maintainer "${MAINTAINER}" \
-            --architecture ${ARCH} \
-            --url "${URL}" \
-            --description  "${DESC}" \
-            --depends "${PKGNAME}-portal-ui-3x = ${VERSION}" \
-            --depends "${PKGNAME}-management-ui-3x = ${VERSION}" \
-            --depends "${PKGNAME}-rest-api-3x = ${VERSION}" \
-            --depends "${PKGNAME}-gateway-3x = ${VERSION}" \
-            --verbose \
-            -n ${PKGNAME}-3x
+  docker run --rm -v "${PWD}:${DOCKER_WDIR}" -w ${DOCKER_WDIR} ${DOCKER_FPM}:rpm -t rpm \
+    --rpm-user ${USER} \
+    --rpm-group ${USER} \
+    --rpm-attr "0750,${USER},${USER}:/opt/graviteeio" \
+    --iteration ${RELEASE} \
+    -C ${TEMPLATE_DIR} \
+    -s dir -v ${VERSION} \
+    --license "${LICENSE}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --architecture ${ARCH} \
+    --url "${URL}" \
+    --description "${DESC}" \
+    --depends "${PKGNAME}-portal-ui-3x = ${VERSION}" \
+    --depends "${PKGNAME}-management-ui-3x = ${VERSION}" \
+    --depends "${PKGNAME}-rest-api-3x = ${VERSION}" \
+    --depends "${PKGNAME}-gateway-3x = ${VERSION}" \
+    --verbose \
+    -n ${PKGNAME}-3x
 }
 
 build() {
-	clean
-	parse_version
-	download
-	build_api_gateway
-	build_rest_api
-	build_management_ui
-	build_portal_ui
-	build_full
+  clean
+  parse_version
+  download
+  build_api_gateway
+  build_rest_api
+  build_management_ui
+  build_portal_ui
+  build_full
 }
 
 ##################################################
 # Startup
 ##################################################
 
-while getopts ':v:l:' o
-do
-    case $o in
-    v) VERSION_WITH_QUALIFIER=$OPTARG ;;
-    h|*) usage ;;
-    esac
+while getopts ':v:l:' o; do
+  case $o in
+  v) VERSION_WITH_QUALIFIER=$OPTARG ;;
+  h | *) usage ;;
+  esac
 done
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 
 TEMPLATE_DIR=build/skel/el
 

--- a/apim/3.x/build/scripts/gateway/postinst.rpm
+++ b/apim/3.x/build/scripts/gateway/postinst.rpm
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-ln -sf /opt/graviteeio/apim/graviteeio-apim-gateway-%{version}/ /opt/graviteeio/apim/gateway
+ln -sf /opt/graviteeio/apim/graviteeio-apim-gateway/ /opt/graviteeio/apim/gateway
 chown -R gravitee:gravitee /opt/graviteeio/apim/gateway

--- a/apim/3.x/build/scripts/management-ui/postinst.rpm
+++ b/apim/3.x/build/scripts/management-ui/postinst.rpm
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ln -sf /opt/graviteeio/apim/graviteeio-apim-console-ui-%{version}/ /opt/graviteeio/apim/management-ui
+ln -sf /opt/graviteeio/apim/graviteeio-apim-console-ui/ /opt/graviteeio/apim/management-ui
 chown -R gravitee:gravitee /opt/graviteeio/apim/management-ui
 
 # Restart nginx process to take care of the new location

--- a/apim/3.x/build/scripts/portal-ui/postinst.rpm
+++ b/apim/3.x/build/scripts/portal-ui/postinst.rpm
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ln -sf /opt/graviteeio/apim/graviteeio-apim-portal-ui-%{version}/ /opt/graviteeio/apim/portal-ui
+ln -sf /opt/graviteeio/apim/graviteeio-apim-portal-ui/ /opt/graviteeio/apim/portal-ui
 chown -R gravitee:gravitee /opt/graviteeio/apim/portal-ui
 
 # Restart nginx process to take care of the new location

--- a/apim/3.x/build/scripts/rest-api/postinst.rpm
+++ b/apim/3.x/build/scripts/rest-api/postinst.rpm
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-ln -sf /opt/graviteeio/apim/graviteeio-apim-rest-api-%{version}/ /opt/graviteeio/apim/rest-api
+ln -sf /opt/graviteeio/apim/graviteeio-apim-rest-api/ /opt/graviteeio/apim/rest-api
 chown -R gravitee:gravitee /opt/graviteeio/apim/rest-api

--- a/apim/4.x/build.sh
+++ b/apim/4.x/build.sh
@@ -68,7 +68,7 @@ download() {
   wget -nv -P .staging "https://download.gravitee.io/${path}${filename}.sha1"
   cd .staging
   sha1sum -c ${filename}.sha1
-  unzip ${filename}
+  unzip -q ${filename}
   rm ${filename}
   rm ${filename}.sha1
   cd ..
@@ -79,9 +79,8 @@ build_api_gateway() {
   rm -fr build/skel/
 
   mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-  ln -sf build/skel/el7/opt/graviteeio/apim/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/gateway
-
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-gateway
+  ln -sf build/skel/el7/opt/graviteeio/apim/graviteeio-apim-gateway ${TEMPLATE_DIR}/opt/graviteeio/apim/gateway
   mkdir -p ${TEMPLATE_DIR}/etc/systemd/system/
   cp build/files/systemd/graviteeio-apim-gateway.service ${TEMPLATE_DIR}/etc/systemd/system/
 
@@ -107,7 +106,7 @@ build_api_gateway() {
     --architecture ${ARCH} \
     --url "${URL}" \
     --description "${DESC}: API Gateway" \
-    --config-files /opt/graviteeio/apim/graviteeio-apim-gateway-${VERSION_WITH_QUALIFIER}/config \
+    --config-files /opt/graviteeio/apim/graviteeio-apim-gateway/config \
     --verbose \
     -n ${PKGNAME}-gateway-4x
 }
@@ -116,9 +115,8 @@ build_rest_api() {
   rm -fr build/skel/
 
   mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/rest-api
-
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api
+  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-rest-api ${TEMPLATE_DIR}/opt/graviteeio/apim/rest-api
   mkdir -p ${TEMPLATE_DIR}/etc/systemd/system/
   cp build/files/systemd/graviteeio-apim-rest-api.service ${TEMPLATE_DIR}/etc/systemd/system/
 
@@ -144,7 +142,7 @@ build_rest_api() {
     --architecture ${ARCH} \
     --url "${URL}" \
     --description "${DESC}: Management API" \
-    --config-files /opt/graviteeio/apim/graviteeio-apim-rest-api-${VERSION_WITH_QUALIFIER}/config \
+    --config-files /opt/graviteeio/apim/graviteeio-apim-rest-api/config \
     --verbose \
     -n ${PKGNAME}-rest-api-4x
 }
@@ -153,9 +151,8 @@ build_management_ui() {
   rm -fr build/skel/
 
   mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/management-ui
-
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui
+  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-console-ui ${TEMPLATE_DIR}/opt/graviteeio/apim/management-ui
   mkdir -p ${TEMPLATE_DIR}/etc/nginx/conf.d/
   cp build/files/graviteeio-apim-management-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
 
@@ -178,7 +175,7 @@ build_management_ui() {
     --url "${URL}" \
     --description "${DESC}: Management UI" \
     --depends nginx \
-    --config-files /opt/graviteeio/apim/graviteeio-apim-console-ui-${VERSION_WITH_QUALIFIER}/constants.json \
+    --config-files /opt/graviteeio/apim/graviteeio-apim-console-ui/constants.json \
     --verbose \
     -n ${PKGNAME}-management-ui-4x
 }
@@ -187,9 +184,8 @@ build_portal_ui() {
   rm -fr build/skel/
 
   mkdir -p ${TEMPLATE_DIR}/opt/graviteeio/apim
-  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim
-  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/portal-ui
-
+  cp -fr .staging/graviteeio-full-${VERSION_WITH_QUALIFIER}/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER} ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui
+  ln -sf ${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui ${TEMPLATE_DIR}/opt/graviteeio/apim/portal-ui
   mkdir -p ${TEMPLATE_DIR}/etc/nginx/conf.d/
   cp build/files/graviteeio-apim-portal-ui.conf ${TEMPLATE_DIR}/etc/nginx/conf.d/
 
@@ -212,7 +208,7 @@ build_portal_ui() {
     --url "${URL}" \
     --description "${DESC}: Portal UI" \
     --depends nginx \
-    --config-files "${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui-${VERSION_WITH_QUALIFIER}/assets/" \
+    --config-files "${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui/assets/" \
     --verbose \
     -n ${PKGNAME}-portal-ui-4x
 }

--- a/apim/4.x/build/scripts/gateway/postinst.rpm
+++ b/apim/4.x/build/scripts/gateway/postinst.rpm
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-## Warning for version with qualifier, `tail -1` works until version .9
-installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-gateway-* | cut -d- -f4,5 | tail -1)
-ln -sf /opt/graviteeio/apim/graviteeio-apim-gateway-"${installedVersion}"/ /opt/graviteeio/apim/gateway
+ln -sf /opt/graviteeio/apim/graviteeio-apim-gateway/ /opt/graviteeio/apim/gateway
 chown -R gravitee:gravitee /opt/graviteeio/apim/gateway

--- a/apim/4.x/build/scripts/management-ui/postinst.rpm
+++ b/apim/4.x/build/scripts/management-ui/postinst.rpm
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-## Warning for version with qualifier, `tail -1` works until version .9
-installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-console-ui-* | cut -d- -f5,6 | tail -1)
-ln -sf /opt/graviteeio/apim/graviteeio-apim-console-ui-"${installedVersion}"/ /opt/graviteeio/apim/management-ui
+ln -sf /opt/graviteeio/apim/graviteeio-apim-console-ui /opt/graviteeio/apim/management-ui
 chown -R gravitee:gravitee /opt/graviteeio/apim/management-ui
 
 # Restart nginx process to take care of the new location

--- a/apim/4.x/build/scripts/portal-ui/postinst.rpm
+++ b/apim/4.x/build/scripts/portal-ui/postinst.rpm
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-## Warning for version with qualifier, `tail -1` works until version .9
-installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-portal-ui-* | cut -d- -f5,6 | tail -1)
-ln -sf /opt/graviteeio/apim/graviteeio-apim-portal-ui-"${installedVersion}"/ /opt/graviteeio/apim/portal-ui
+ln -sf /opt/graviteeio/apim/graviteeio-apim-portal-ui /opt/graviteeio/apim/portal-ui
 chown -R gravitee:gravitee /opt/graviteeio/apim/portal-ui
 
 # Restart nginx process to take care of the new location

--- a/apim/4.x/build/scripts/rest-api/postinst.rpm
+++ b/apim/4.x/build/scripts/rest-api/postinst.rpm
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-## Warning for version with qualifier, `tail -1` works until version .9
-installedVersion=$(ls -d /opt/graviteeio/apim/graviteeio-apim-rest-api-* | cut -d- -f5,6 | tail -1)
-ln -sf /opt/graviteeio/apim/graviteeio-apim-rest-api-"${installedVersion}"/ /opt/graviteeio/apim/rest-api
+ln -sf /opt/graviteeio/apim/graviteeio-apim-rest-api /opt/graviteeio/apim/rest-api
 chown -R gravitee:gravitee /opt/graviteeio/apim/rest-api


### PR DESCRIPTION
The issue was during upgrade, as the installation folder contained version
number inside their path. During upgrade, the previous config file was
keeped on previous installation folder with the extention `.rpmsave`.

By removing the version number from the installation folder path, the
RPM configuration work as expected by keeping the existing configuration file.

Note: the readme is completed with a testing senario wich describe the upgrade
process.

https://gravitee.atlassian.net/browse/APIM-3237
https://github.com/gravitee-io/issues/issues/9368