### PR TITLE
fix(apim4): fix SystemD usage

### DIFF
--- a/apim/4.x/build/scripts/gateway/postinst.rpm
+++ b/apim/4.x/build/scripts/gateway/postinst.rpm
@@ -2,3 +2,9 @@
 
 ln -sf /opt/graviteeio/apim/graviteeio-apim-gateway/ /opt/graviteeio/apim/gateway
 chown -R gravitee:gravitee /opt/graviteeio/apim/gateway
+
+if [ "systemd" = "$(ps -p 1 -o comm=)" ] && [ -f /etc/init.d/graviteeio-apim-gateway ]
+then
+  echo "As systemd is in place, we remove the sysV script from /etc/init.d/ folder."
+  rm -f /etc/init.d/graviteeio-apim-gateway
+fi

--- a/apim/4.x/build/scripts/management-ui/postinst.rpm
+++ b/apim/4.x/build/scripts/management-ui/postinst.rpm
@@ -3,5 +3,8 @@
 ln -sf /opt/graviteeio/apim/graviteeio-apim-console-ui /opt/graviteeio/apim/management-ui
 chown -R gravitee:gravitee /opt/graviteeio/apim/management-ui
 
-# Restart nginx process to take care of the new location
-systemctl restart nginx
+if [ "systemd" = "$(ps -p 1 -o comm=)" ]
+then
+  # Restart nginx process to take care of the new location
+  systemctl restart nginx
+fi

--- a/apim/4.x/build/scripts/portal-ui/postinst.rpm
+++ b/apim/4.x/build/scripts/portal-ui/postinst.rpm
@@ -3,5 +3,9 @@
 ln -sf /opt/graviteeio/apim/graviteeio-apim-portal-ui /opt/graviteeio/apim/portal-ui
 chown -R gravitee:gravitee /opt/graviteeio/apim/portal-ui
 
-# Restart nginx process to take care of the new location
-systemctl restart nginx
+
+if [ "systemd" = "$(ps -p 1 -o comm=)" ]
+then
+  # Restart nginx process to take care of the new location
+  systemctl restart nginx
+fi

--- a/apim/4.x/build/scripts/rest-api/postinst.rpm
+++ b/apim/4.x/build/scripts/rest-api/postinst.rpm
@@ -2,3 +2,9 @@
 
 ln -sf /opt/graviteeio/apim/graviteeio-apim-rest-api /opt/graviteeio/apim/rest-api
 chown -R gravitee:gravitee /opt/graviteeio/apim/rest-api
+
+if [ "systemd" = "$(ps -p 1 -o comm=)" ] && [ -f /etc/init.d/graviteeio-apim-gateway ]
+then
+  echo "As systemd is in place, we remove the sysV script from /etc/init.d/ folder."
+  rm -vf /etc/init.d/graviteeio-apim-gateway
+fi


### PR DESCRIPTION
fix(apim4): fix SystemD usage

Previously, the SysV init.d script was always installed on targeted OS.
This implies that SystemD will detect the init.d script and try to use
it.
This cause an issue in Suze 15 as there SystemD compatibility has an
issue.

The fix consist of removing the init.d script if the OS use SystemD.
As is, SystemD will not work as SysV compatibility and will use the
provided SystemD config file as expected.

Tested on:

* RedHat 9.3
* Centos stream 9
* Centos 7
* Suze 15

with installation and upgrade scenarios.

TT-4048
APIM-3830
