### PR TITLE
fix(portal): do not overwrite portal config file during upgrade

### DIFF
--- a/apim/4.x/build.sh
+++ b/apim/4.x/build.sh
@@ -208,7 +208,7 @@ build_portal_ui() {
     --url "${URL}" \
     --description "${DESC}: Portal UI" \
     --depends nginx \
-    --config-files "${TEMPLATE_DIR}/opt/graviteeio/apim/graviteeio-apim-portal-ui/assets/" \
+    --config-files "/opt/graviteeio/apim/graviteeio-apim-portal-ui/assets/config.json" \
     --verbose \
     -n ${PKGNAME}-portal-ui-4x
 }


### PR DESCRIPTION
This commit fix the fact that portal configuration file:
`/opt/graviteeio/apim/graviteeio-apim-portal-ui/assets/config.json"`
was overwrite during yum upgrade.

TT-4996
APIM-6148
