### PR TITLE
fix(am): fix SystemD usage

### DIFF
--- a/am/4.x/build/scripts/gateway/postinst.rpm
+++ b/am/4.x/build/scripts/gateway/postinst.rpm
@@ -2,3 +2,9 @@
 
 ln -sf /opt/graviteeio/am/graviteeio-am-gateway/ /opt/graviteeio/am/gateway
 chown -R gravitee:gravitee /opt/graviteeio/am/gateway
+
+if [ "systemd" = "$(ps -p 1 -o comm=)" ] && [ -f /etc/init.d/graviteeio-am-gateway ]
+then
+  echo "As systemd is in place, we remove the sysV script from /etc/init.d/ folder."
+  rm -f /etc/init.d/graviteeio-am-gateway
+fi

--- a/am/4.x/build/scripts/management-api/postinst.rpm
+++ b/am/4.x/build/scripts/management-api/postinst.rpm
@@ -2,3 +2,9 @@
 
 ln -sf /opt/graviteeio/am/graviteeio-am-management-api/ /opt/graviteeio/am/management-api
 chown -R gravitee:gravitee /opt/graviteeio/am/management-api
+
+if [ "systemd" = "$(ps -p 1 -o comm=)" ] && [ -f /etc/init.d/graviteeio-am-management-api ]
+then
+  echo "As systemd is in place, we remove the sysV script from /etc/init.d/ folder."
+  rm -vf /etc/init.d/graviteeio-am-management-api
+fi

--- a/am/4.x/build/scripts/management-ui/postinst.rpm
+++ b/am/4.x/build/scripts/management-ui/postinst.rpm
@@ -3,5 +3,11 @@
 ln -sf /opt/graviteeio/am/graviteeio-am-management-ui/ /opt/graviteeio/am/management-ui
 chown -R gravitee:gravitee /opt/graviteeio/am/management-ui
 
-# Restart nginx process to take care of the new location
-systemctl restart nginx
+if [ "systemd" = "$(ps -p 1 -o comm=)" ]; then
+  # Restart nginx process to take care of the new location
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart nginx
+  elif command -v service >/dev/null 2>&1; then
+    service restart nginx
+  fi
+fi


### PR DESCRIPTION
Previously, the SysV init.d script was always installed on targeted OS. This implies that SystemD will detect the init.d script and try to use it. This cause an issue in Suze 15 as there SystemD compatibility has an issue.

The fix consist of removing the init.d script if the OS use SystemD. As is, SystemD will not work as SysV compatibility and will use the provided SystemD config file as expected.

AM-4840